### PR TITLE
chore: update access to public

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -108,7 +108,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc --project tsconfig.build.json && oclif-dev manifest && oclif-dev readme",
     "test": "tsc --emitDeclarationOnly && jest",
-    "npm:publish": "yarn npm publish --tolerate-republish",
+    "npm:publish": "yarn npm publish --access public --tolerate-republish",
     "version": "oclif-dev readme && git add README.md",
     "nitric": "./bin/run"
   },

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -9,7 +9,7 @@
     "build": "yarn run clean && yarn run build:sources",
     "build:sources": "tsc --project tsconfig.build.json --outDir ./lib/",
     "test": "tsc --emitDeclarationOnly && jest",
-    "npm:publish": "yarn npm publish --tolerate-republish",
+    "npm:publish": "yarn npm publish --access public --tolerate-republish",
     "license:check": "licensee --production"
   },
   "contributors": [

--- a/packages/plugins/aws/package.json
+++ b/packages/plugins/aws/package.json
@@ -67,7 +67,7 @@
     "prepack": "rm -rf lib && tsc -p tsconfig.build.json && oclif-dev manifest && oclif-dev readme",
     "test": "tsc --emitDeclarationOnly && jest --passWithNoTests",
     "version": "oclif-dev readme && git add README.md",
-    "npm:publish": "yarn npm publish --tolerate-republish",
+    "npm:publish": "yarn npm publish --access public --tolerate-republish",
     "license:check": "licensee --production"
   }
 }

--- a/packages/plugins/do/package.json
+++ b/packages/plugins/do/package.json
@@ -62,6 +62,6 @@
     "test": "tsc --emitDeclarationOnly && jest --passWithNoTests",
     "version": "oclif-dev readme && git add README.md",
     "license:check": "licensee --production",
-    "npm:publish": "yarn npm publish --tolerate-republish"
+    "npm:publish": "yarn npm publish --access public --tolerate-republish"
   }
 }

--- a/packages/plugins/gcp/package.json
+++ b/packages/plugins/gcp/package.json
@@ -67,6 +67,6 @@
     "test": "tsc --emitDeclarationOnly && jest --passWithNoTests",
     "version": "oclif-dev readme && git add README.md",
     "license:check": "licensee --production",
-    "npm:publish": "yarn npm publish --tolerate-republish"
+    "npm:publish": "yarn npm publish --access public --tolerate-republish"
   }
 }


### PR DESCRIPTION
Turns out scoped packages default to 'restricted' when publishing to NPM, so the previous change to remove the explicit restriction didn't make the packages public, this should.