### PR TITLE
Fix stack names for digital ocean plugins.

### DIFF
--- a/packages/plugins/do/src/tasks/deploy/index.ts
+++ b/packages/plugins/do/src/tasks/deploy/index.ts
@@ -80,8 +80,8 @@ export class Deploy extends Task<DeployResults> {
 			// Upload the stack
 			const pulumiStack = await LocalWorkspace.createOrSelectStack({
 				// TODO: Incorporate additional stack detail. E.g. dev/test/prod
-				stackName: 'do',
-				projectName: `${stack.getName()}-do`,
+				stackName: `${stack.getName()}-do`,
+				projectName: stack.getName(),
 				// generate our pulumi program on the fly from the POST body
 				program: async () => {
 					// Now we can start deploying with Pulumi


### PR DESCRIPTION
Fixes stacknames for digital ocean deploys to make them unique, note that this will change to way the prod website deploys and the CNAMEs will need to be updates and original site pulled down.