### PR TITLE
fix: fix directories failing to be created

### DIFF
--- a/packages/base/src/tasks/make/stack.test.ts
+++ b/packages/base/src/tasks/make/stack.test.ts
@@ -22,7 +22,7 @@ describe('MakeStackTask: ', () => {
 	describe("When the stack folder doesn't exist", () => {
 		test('The new stack directory is created', async () => {
 			await new MakeStackTask({ name: 'test-stack', force: true }).do();
-			expect(fs.mkdirSync).toBeCalledWith('./test-stack');
+			expect(fs.mkdirSync).toBeCalledWith('./test-stack', { recursive: true });
 		});
 	});
 

--- a/packages/base/src/tasks/make/stack.ts
+++ b/packages/base/src/tasks/make/stack.ts
@@ -55,7 +55,7 @@ export class MakeStackTask extends Task<void> {
 
 		// Create new folder relative to current directory for the new project
 		try {
-			fs.mkdirSync(stackPath);
+			fs.mkdirSync(stackPath, { recursive: true });
 		} catch (error) {
 			if (error.message.includes('file already exists')) {
 				if (!this.force) {

--- a/packages/base/src/tasks/run/gateway.ts
+++ b/packages/base/src/tasks/run/gateway.ts
@@ -40,7 +40,7 @@ export interface RunGatewayTaskOptions {
  */
 export function createAPIStagingDirectory(): string {
 	if (!fs.existsSync(`${STAGING_API_DIR}`)) {
-		fs.mkdirSync(`${STAGING_API_DIR}`);
+		fs.mkdirSync(`${STAGING_API_DIR}`, { recursive: true });
 	}
 
 	return `${STAGING_API_DIR}`;
@@ -52,7 +52,7 @@ export function createAPIStagingDirectory(): string {
 export function createAPIDirectory(apiName: string): string {
 	const stagingDir = createAPIStagingDirectory();
 	if (!fs.existsSync(`${stagingDir}/${apiName}`)) {
-		fs.mkdirSync(`${stagingDir}/${apiName}`);
+		fs.mkdirSync(`${stagingDir}/${apiName}`, { recursive: true });
 	}
 
 	return `${stagingDir}/${apiName}`;

--- a/packages/base/src/utils/index.ts
+++ b/packages/base/src/utils/index.ts
@@ -21,7 +21,7 @@ import path from 'path';
  */
 export function createNitricLogDir(): void {
 	if (!fs.existsSync(LOG_DIR)) {
-		fs.mkdirSync(LOG_DIR);
+		fs.mkdirSync(LOG_DIR, { recursive: true });
 	}
 }
 


### PR DESCRIPTION
Directories have been failing to create when intermediate directories are missing. Main example is api gateway staging directories.