### PR TITLE
fix:  don't call stdin.setRawMode if it doesn't exist

### DIFF
--- a/packages/base/src/commands/run.ts
+++ b/packages/base/src/commands/run.ts
@@ -518,8 +518,10 @@ export default class Run extends BaseCommand {
 				});
 			});
 
-			process.stdin.setRawMode!(true);
-			process.stdin.resume();
+			if (process.stdin.setRawMode) {
+				process.stdin.setRawMode(true);
+				process.stdin.resume();
+			}
 
 			await cleanUp;
 


### PR DESCRIPTION
Closes #175 