### PR TITLE
Start minio server for storage

### DIFF
--- a/packages/base/src/tasks/run/constants.ts
+++ b/packages/base/src/tasks/run/constants.ts
@@ -13,3 +13,7 @@
 // limitations under the License.
 
 export const NITRIC_DEV_VOLUME = '/nitric/';
+
+export const NITRIC_RUN_DIR = './.nitric/run';
+// NOTE: octal notation is important here!!!
+export const NITRIC_RUN_PERM = 0o777;

--- a/packages/base/src/tasks/run/function.ts
+++ b/packages/base/src/tasks/run/function.ts
@@ -82,7 +82,15 @@ export class RunContainerTask extends Task<Container> {
 
 		const dockerOptions = {
 			name: `${this.image.name}-${runId}`,
-			Env: [`LOCAL_SUBSCRIPTIONS=${JSON.stringify(subscriptions)}`, `NITRIC_DEV_VOLUME=${NITRIC_DEV_VOLUME}`],
+			Env: [
+				`LOCAL_SUBSCRIPTIONS=${JSON.stringify(subscriptions)}`,
+				`NITRIC_DEV_VOLUME=${NITRIC_DEV_VOLUME}`,
+				// ENV variables to connect the membrane to a local minio instance
+				`MINIO_ENDPOINT=http://minio-${runId}:9000`,
+				// TODO: Update these from defaults
+				`MINIO_ACCESS_KEY=minioadmin`,
+				`MINIO_SECRET_KEY=minioadmin`,
+			],
 			ExposedPorts: {
 				[`${GATEWAY_PORT}/tcp`]: {},
 			},

--- a/packages/base/src/tasks/run/index.ts
+++ b/packages/base/src/tasks/run/index.ts
@@ -16,3 +16,4 @@ export * from './network';
 export * from './function';
 export * from './gateway';
 export * from './entrypoints';
+export * from './storage';

--- a/packages/base/src/tasks/run/storage.ts
+++ b/packages/base/src/tasks/run/storage.ts
@@ -1,0 +1,174 @@
+// Copyright 2021, Nitric Technologies Pty Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { NamedObject, NitricBucket, Stack, Task } from '@nitric/cli-common';
+import Docker, { Container, ContainerCreateOptions, Network, NetworkInspectInfo } from 'dockerode';
+import fs from 'fs';
+import path from 'path';
+import getPort from 'get-port';
+import streamToPromise from 'stream-to-promise';
+import { DOCKER_LABEL_RUN_ID } from '../../constants';
+import { NITRIC_RUN_DIR, NITRIC_RUN_PERM, NITRIC_DEV_VOLUME } from './constants';
+
+const MINIO_PORT = 9000;
+// TODO: Determine if we would like to expose the console
+const MINIO_CONSOLE_PORT = 9001;
+
+/**
+ * Starts an exec stream and Wraps the docker.modem.followProgress function on non-windows platforms
+ * For windows a workaround using exec.inspect is used to ensure we can capture the end of the stream
+ * @param exec
+ * @param docker
+ */
+//export async function execStream(exec: Docker.Exec, docker: Docker): Promise<void> {
+//	const execStream = await exec.start({});
+
+//	await new Promise<void>((resolve) => {
+//		if (os.platform() == 'win32') {
+//			let output = '';
+//			execStream.on('data', (chunk) => (output += chunk));
+
+//			const interval = setInterval(async () => {
+//				const { Running } = await exec.inspect();
+
+//				if (!Running) {
+//					clearInterval(interval);
+//					execStream.destroy();
+//					resolve();
+//				}
+//			}, 100);
+//		} else {
+//			docker.modem.followProgress(execStream, resolve);
+//		}
+//	});
+//}
+
+/**
+ * Options when running entrypoints for local testing
+ */
+export interface RunStorageServiceTaskOptions {
+	stack: Stack;
+	buckets: NamedObject<NitricBucket>[];
+	network?: Network;
+	port?: number;
+	consolePort?: number;
+	runId: string;
+}
+
+/**
+ * Run local http entrypoint(s) as containers for developments/testing purposes.
+ */
+export class RunStorageServiceTask extends Task<Container> {
+	private stack: Stack;
+	private buckets: NamedObject<NitricBucket>[];
+	private network?: Network;
+	private docker: Docker;
+	private port?: number;
+	private consolePort?: number;
+	private runId: string;
+
+	constructor({ stack, buckets, network, port, consolePort, runId }: RunStorageServiceTaskOptions, docker: Docker) {
+		super(`minio server`);
+		this.stack = stack;
+		this.buckets = buckets;
+		this.network = network;
+		this.docker = docker;
+		this.port = port;
+		this.consolePort = consolePort;
+		this.runId = runId;
+	}
+
+	async do(): Promise<Container> {
+		const { buckets, network, docker, runId } = this;
+
+		if (!this.port) {
+			// Find any open port if none provided.
+			this.port = await getPort();
+		}
+
+		if (!this.consolePort) {
+			this.consolePort = await getPort();
+		}
+
+		let networkName = 'bridge';
+		if (network) {
+			try {
+				networkName = ((await network?.inspect()) as NetworkInspectInfo).Name;
+			} catch (error) {
+				console.warn(`Failed to set custom docker network, defaulting to bridge network`);
+			}
+		}
+
+		// Ensure the buckets directory exists
+		const nitricRunDir = path.join(this.stack.getDirectory(), NITRIC_RUN_DIR);
+		fs.mkdirSync(nitricRunDir, { recursive: true });
+		fs.chmodSync(nitricRunDir, NITRIC_RUN_PERM);
+		await Promise.all(
+			buckets.map((b) => fs.promises.mkdir(path.join(nitricRunDir, `./buckets/${b.name}`), { recursive: true })),
+		);
+
+		// Add storage volume, if configured
+		const MOUNT_POINT = `${NITRIC_DEV_VOLUME}`;
+
+		// Pull nginx
+		await streamToPromise(await docker.pull('minio/minio'));
+
+		const dockerOptions = {
+			name: `minio-${runId}`,
+			// Pull nginx
+			Image: 'minio/minio',
+			ExposedPorts: {
+				[`${MINIO_PORT}/tcp`]: {},
+				[`${MINIO_CONSOLE_PORT}/tcp`]: {},
+			},
+			Volumes: {
+				[MOUNT_POINT]: {},
+			},
+			Labels: {
+				[DOCKER_LABEL_RUN_ID]: runId,
+			},
+			Cmd: ['server', '/nitric/buckets', '--console-address', `:${MINIO_CONSOLE_PORT}`],
+			HostConfig: {
+				NetworkMode: networkName,
+				PortBindings: {
+					[`${MINIO_PORT}/tcp`]: [
+						{
+							HostPort: `${this.port}/tcp`,
+						},
+					],
+					[`${MINIO_CONSOLE_PORT}/tcp`]: [
+						{
+							HostPort: `${this.consolePort}/tcp`,
+						},
+					],
+				},
+				Mounts: [
+					{
+						Target: MOUNT_POINT,
+						Source: nitricRunDir, // volume.name,
+						Type: 'bind',
+					},
+				],
+			},
+		} as ContainerCreateOptions;
+
+		// Create the nginx source first
+		const container = await docker.createContainer(dockerOptions);
+
+		// Start the entrypoint source
+		await container.start();
+
+		return container;
+	}
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -24,6 +24,7 @@
 	],
 	"license": "Apache-2.0",
 	"dependencies": {
+		"@iarna/toml": "^2.2.5",
 		"@oclif/command": "^1",
 		"@oclif/config": "^1",
 		"@pulumi/docker": "^3.0.0",

--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import path from 'path';
 import { ListrBaseClassOptions, ListrDefaultRendererValue, ListrFallbackRendererValue } from 'listr2';
+
+export const DEFAULT_NITRIC_DIR = '.nitric/';
+export const DEFAULT_BUILD_DIR = path.join(DEFAULT_NITRIC_DIR, 'build');
 
 export const DEFAULT_LISTR_OPTIONS: ListrBaseClassOptions<any, ListrDefaultRendererValue, ListrFallbackRendererValue> =
 	{

--- a/packages/common/src/stack/schema.ts
+++ b/packages/common/src/stack/schema.ts
@@ -1572,6 +1572,12 @@ export const STACK_SCHEMA: JSONSchema7 = {
 						},
 						handler: { type: 'string' },
 						context: { type: 'string' },
+						excludes: {
+							type: 'array',
+							items: {
+								type: 'string',
+							},
+						},
 						triggers: {
 							title: 'func triggers',
 							type: 'object',

--- a/packages/common/src/types/compute/function.ts
+++ b/packages/common/src/types/compute/function.ts
@@ -24,7 +24,6 @@ export interface NitricFunction<Ext> extends NitricComputeUnit<Ext> {
 	// build process before beginning the docker build
 	buildScripts?: string[];
 	// files to exclude from final build
-	// can be globs
 	excludes?: string[];
 	// The most requests a single function instance should handle
 	maxRequests?: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@iarna/toml@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "@iarna/toml@npm:2.2.5"
+  checksum: 929a8516a24996b75768f7e0591815e37004f2cdda12b245c9a5ae64f423b4bd2bdd6943fc80e9bb5360a7be0b6d05bac57c178578d9a73acfb2eab125c594ee
+  languageName: node
+  linkType: hard
+
 "@istanbuljs/load-nyc-config@npm:^1.0.0":
   version: 1.1.0
   resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
@@ -747,6 +754,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nitric/cli-common@workspace:packages/common"
   dependencies:
+    "@iarna/toml": ^2.2.5
     "@oclif/command": ^1
     "@oclif/config": ^1
     "@pulumi/docker": ^3.0.0


### PR DESCRIPTION
Starts a minio server mounted to .nitric/run/buckets to manage buckets via the s3 plugin for local deployments.