### PR TITLE
fix: GCP: Schedules - topic name for pubsubTarget updated to pass the gcloud validation.

### DIFF
--- a/packages/plugins/gcp/src/resources/schedule.ts
+++ b/packages/plugins/gcp/src/resources/schedule.ts
@@ -27,7 +27,12 @@ interface NitricScheduleCloudSchedulerArgs {
 export class NitricScheduleCloudScheduler extends pulumi.ComponentResource {
 	public readonly job: gcp.cloudscheduler.Job;
 
-	constructor(name: string, args: NitricScheduleCloudSchedulerArgs, opts?: pulumi.ComponentResourceOptions) {
+	constructor(
+		projectId: string,
+		name: string,
+		args: NitricScheduleCloudSchedulerArgs,
+		opts?: pulumi.ComponentResourceOptions,
+	) {
 		super('nitric:schedule:CloudScheduler', name, {}, opts);
 		const { schedule, topics } = args;
 		const defaultResourceOptions: pulumi.ResourceOptions = { parent: this };
@@ -41,7 +46,8 @@ export class NitricScheduleCloudScheduler extends pulumi.ComponentResource {
 					timeZone: 'UTC',
 					description: `scheduled trigger for ${schedule.target.name}`,
 					pubsubTarget: {
-						topicName: topic.pubsub.name,
+						// Interpolate required by pulumi to translate output<T> into string
+						topicName: pulumi.interpolate`${projectId}/topics/${topic.pubsub.name}`,
 						data: Buffer.from(JSON.stringify(schedule.event)).toString('base64'),
 					},
 					schedule: schedule.expression?.replace(/['"]+/g, ''),

--- a/packages/plugins/gcp/src/tasks/deploy/index.ts
+++ b/packages/plugins/gcp/src/tasks/deploy/index.ts
@@ -168,6 +168,7 @@ export class Deploy extends Task<DeployResult> {
 						mapObject(schedules).map(
 							(s) =>
 								new NitricScheduleCloudScheduler(
+									project.id,
 									s.name,
 									{ schedule: s, topics: deployedTopics },
 									defaultResourceOptions,


### PR DESCRIPTION
Format was passing in "TOPIC_ID" but requires project/PROEJCT_ID/topics/TOPIC_ID