### PR TITLE
feat(gcp): gcp deploy doesn't detect default project configured

### DIFF
--- a/packages/plugins/gcp/src/commands/deploy/gcp.ts
+++ b/packages/plugins/gcp/src/commands/deploy/gcp.ts
@@ -100,7 +100,7 @@ export default class GcpDeploy extends BaseCommand {
 		const auth = new google.auth.GoogleAuth({
 			scopes: ['https://www.googleapis.com/auth/cloud-platform'],
 		});
-		const derivedProject = (await auth.getClient()).projectId;
+		const derivedProject = await auth.getProjectId();
 		const { args, flags } = this.parse(GcpDeploy);
 		const { nonInteractive } = flags;
 		const { dir = '.' } = args;


### PR DESCRIPTION
Setting a default project using `gcloud config set project PROJECT_ID` isn't detected when deploying to gcp